### PR TITLE
fix 'local variable 'local_filename' referenced before assignment'

### DIFF
--- a/mpicpy.py
+++ b/mpicpy.py
@@ -117,6 +117,7 @@ def main(filepath, root='auto', chunksize='4m', rank_suffix=False):
     assert type(root) == int
     assert 0 <= root and root < comm.size
 
+    local_filename = filepath
     if rank_suffix:
         local_filename = '{}.{}'.format(filepath, comm.rank)
 


### PR DESCRIPTION
```shell
# mpiexec --allow-run-as-root -N 1 -n 2 -hostfile /tmp/hostfile -mca btl tcp,self -mca btl_tcp_if_include=eth0 -- python /mpicpy.py --filepath=/myfile
Rank 0 [Root] size=224581741392
num_chunks = 53545
Sending Chunk #1
Traceback (most recent call last):
  File "/mpicpy.py", line 132, in <module>
    fire.Fire(main)
  File "/usr/local/lib/python3.6/site-packages/fire/core.py", line 138, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/usr/local/lib/python3.6/site-packages/fire/core.py", line 471, in _Fire
    target=component.__name__)
  File "/usr/local/lib/python3.6/site-packages/fire/core.py", line 675, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "/mpicpy.py", line 128, in main
    recv_file(root, local_filename, chunksize)
UnboundLocalError: local variable 'local_filename' referenced before assignment
```